### PR TITLE
added dotenv-webpack dependency. Webpack needs this dependency to acc…

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -24,6 +24,7 @@
   "dependencies": {
     "axios": "^0.27.2",
     "css-loader": "^6.7.1",
+    "dotenv-webpack": "^7.1.0",
     "react": "^18.1.0",
     "react-dom": "^18.1.0",
     "react-router-dom": "^6.3.0",

--- a/client/webpack.config.js
+++ b/client/webpack.config.js
@@ -1,5 +1,7 @@
 const HtmlWebPackPlugin = require( 'html-webpack-plugin' )
 const path = require( 'path' )
+const Dotenv = require('dotenv-webpack')
+
 module.exports = {
     mode: 'development',
     context: __dirname,
@@ -40,6 +42,7 @@ module.exports = {
         new HtmlWebPackPlugin({
             template: path.resolve( __dirname, 'public/index.html' ),
             filename: 'index.html'
-        })
+        }),
+        new Dotenv()
     ]
     }

--- a/client/yarn.lock
+++ b/client/yarn.lock
@@ -1877,6 +1877,25 @@ dot-case@^3.0.4:
     no-case "^3.0.4"
     tslib "^2.0.3"
 
+dotenv-defaults@^2.0.2:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/dotenv-defaults/-/dotenv-defaults-2.0.2.tgz#6b3ec2e4319aafb70940abda72d3856770ee77ac"
+  integrity sha512-iOIzovWfsUHU91L5i8bJce3NYK5JXeAwH50Jh6+ARUdLiiGlYWfGw6UkzsYqaXZH/hjE/eCd/PlfM/qqyK0AMg==
+  dependencies:
+    dotenv "^8.2.0"
+
+dotenv-webpack@^7.1.0:
+  version "7.1.0"
+  resolved "https://registry.yarnpkg.com/dotenv-webpack/-/dotenv-webpack-7.1.0.tgz#211fefac6bf500bf3bb66b286e1b12a23a2a70c0"
+  integrity sha512-+aUOe+nqgLerA/n611oyC15fY79BIkGm2fOxJAcHDonMZ7AtDpnzv/Oe591eHAenIE0t6w03UyxDnLs/YUxx5Q==
+  dependencies:
+    dotenv-defaults "^2.0.2"
+
+dotenv@^8.2.0:
+  version "8.6.0"
+  resolved "https://registry.yarnpkg.com/dotenv/-/dotenv-8.6.0.tgz#061af664d19f7f4d8fc6e4ff9b584ce237adcb8b"
+  integrity sha512-IrPdXQsk2BbzvCBGBOTmmSH5SodmqZNt4ERAZDmW4CT+tL8VtvinqywuANaFu4bOMWki16nqf0e4oC0QIaDr/g==
+
 ee-first@1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/ee-first/-/ee-first-1.1.1.tgz#590c61156b0ae2f4f0255732a158b266bc56b21d"


### PR DESCRIPTION
…ess process.env. The server is configuring another dependency, dotenv. This gives the config file access to the environment variables in the root. When dotenv-webpack loads, it states env not found because there is no env file in client.